### PR TITLE
3.0.0: Configurable log file name prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mt_logger"
-version = "2.2.1"
+version = "3.0.0"
 authors = ["CJ McAllister <cjm571@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0-only"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 `mt_logger` is a multithreaded Rust logging library focused on traceability, and ease-of-use via macros.
 
-Logs are stored in a `logs` directory, located inside the current working directory when a program is launched. The directory will be created if it does not already exist. Log file names conform to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), with the exception that `:` is replaced with `_` to meet Windows filename requirements.
+Logs are stored in a `logs` directory, located inside the current working directory when a program is launched. The directory will be created if it does not already exist. Log file names conform to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), with the exception that `:` is replaced with `_` to meet Windows file naming requirements. By default, the package name (pulled from `CARGO_PKG_NAME` environment variable) is prepended to the log file name.  
+Example: `cool_game_engine/logs/cool_game_engine_2021-06-27T22_08_38.474-0600.log`
 
 At initialization, a thread is created to receive log messages and commands from the main thread. Timestamps are set before sending in order to maintain complete traceability.
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -51,6 +51,9 @@ const LEVEL_LABEL_WIDTH: usize = 9;
 /// Padding to the left of the log message
 const MESSAGE_LEFT_PADDING: usize = 3;
 
+/// Logfile directory location
+const LOGFILE_DIR: &str = "logs";
+
 #[cfg(test)]
 pub const STDOUT_FILENAME: &str = "logs/stdout_redirect.log";
 #[cfg(test)]
@@ -62,6 +65,7 @@ pub const FILE_OUT_FILENAME: &str = "logs/file_out_redirect.log";
 ///////////////////////////////////////////////////////////////////////////////
 
 pub struct Receiver {
+    logfile_prefix: &'static str,
     logger_rx: mpsc::Receiver<Command>,
     output_level: Level,
     output_stream: OutputStream,
@@ -76,12 +80,14 @@ pub struct Receiver {
 impl Receiver {
     /// Fully-qualified constructor
     pub fn new(
+        logfile_prefix: &'static str,
         logger_rx: mpsc::Receiver<Command>,
         output_level: Level,
         output_stream: OutputStream,
         msg_count: Arc<AtomicU64>,
     ) -> Self {
         Self {
+            logfile_prefix,
             logger_rx,
             output_level,
             output_stream,
@@ -103,14 +109,13 @@ impl Receiver {
         );
 
         // Open a logfile, creating logs directory if necessary
-        let logfile_dir = "logs";
-        //FEAT: Genericize this
         let logfile_name = format!(
-            "mt_log_{}.log",
+            "{}_{}.log",
+            self.logfile_prefix,
             start_time.format(FILE_TIMESTAMP_FORMAT)
         );
 
-        let mut path_buf = PathBuf::from(logfile_dir);
+        let mut path_buf = PathBuf::from(LOGFILE_DIR);
         if !path_buf.as_path().exists() {
             match fs::create_dir(path_buf.as_path()) {
                 Ok(()) => (),


### PR DESCRIPTION
- Defaults to CARGO_PKG_NAME environment variable
- Fixed issue with using Local::now() directly in macro